### PR TITLE
Added logHeaders and logRequestPayload and logResponsePayload options closes #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Creates a new GoodConsole object with the following arguments:
 - `[options]` - optional object with the following available keys
 	- `format` - [MomentJS](http://momentjs.com/docs/#/displaying/format/) format string. Defaults to 'YYMMDD/HHmmss.SSS'.
 	- `utc` - boolean controlling Moment using [utc mode](http://momentjs.com/docs/#/parsing/utc/) or not. Defaults to `true`.
+	- `logHeaders` - log the headers from the request if present. You have to enable `requestHeaders` in Good for this. Defaults to `false`.
+	- `logResponsePayload` - log the response payload if present. Defaults to `true`.
+	- `logRequestPayload` - log the request payload if present. You have to enable `requestPayload` in Good for this. Defaults to `false`.
 
 ## Good Console Methods
 ### `goodconsole.init(stream, emitter, callback)`

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,10 @@ var Through = require('through2');
 var internals = {
     defaults: {
         format: 'YYMMDD/HHmmss.SSS',
-        utc: true
+        utc: true,
+        logHeaders: false,
+        logRequestPayload: false,
+        logResponsePayload: true
     }
 };
 
@@ -115,13 +118,7 @@ internals.GoodConsole.prototype._printEvent = function (event) {
 
 internals.GoodConsole.prototype._formatResponse = function (event, tags) {
 
-    var query = event.query ? JSON.stringify(event.query) : '';
-    var responsePayload = '';
-    var statusCode = '';
-
-    if (typeof event.responsePayload === 'object' && event.responsePayload) {
-        responsePayload = 'response payload: ' + SafeStringify(event.responsePayload);
-    }
+    var data = [event.instance + ':'];
 
     var methodColors = {
         get: 32,
@@ -131,7 +128,12 @@ internals.GoodConsole.prototype._formatResponse = function (event, tags) {
     };
     var color = methodColors[event.method] || 34;
     var method = '\x1b[1;' + color + 'm' + event.method + '\x1b[0m';
+    data.push(method, event.path);
 
+    var query = event.query ? JSON.stringify(event.query) : '';
+    data.push(query);
+
+    var statusCode = '';
     if (event.statusCode) {
         color = 32;
         if (event.statusCode >= 500) {
@@ -143,11 +145,22 @@ internals.GoodConsole.prototype._formatResponse = function (event, tags) {
         }
         statusCode = '\x1b[' + color + 'm' + event.statusCode + '\x1b[0m';
     }
+    data.push(statusCode, '(' + event.responseTime + 'ms)');
+
+    if (this._settings.logHeaders && event.headers) {
+        data.push('headers: ' + SafeStringify(event.headers));
+    }
+    if (this._settings.logRequestPayload && typeof event.requestPayload === 'object' && event.requestPayload) {
+        data.push('request payload: ' + SafeStringify(event.requestPayload));
+    }
+    if (this._settings.logResponsePayload && typeof event.responsePayload === 'object' && event.responsePayload) {
+        data.push('response payload: ' + SafeStringify(event.responsePayload));
+    }
 
     return this._printEvent({
         timestamp: event.timestamp,
         tags: tags,
-        //instance, method, path, query, statusCode, responseTime, responsePayload
-        data: Hoek.format('%s: %s %s %s %s (%sms) %s', event.instance, method, event.path, query, statusCode, event.responseTime, responsePayload)
+        //instance, method, path, query, statusCode, responseTime, requestHeaders, requestPayload, responsePayload
+        data: data.join(' ')
     });
 };

--- a/test/index.js
+++ b/test/index.js
@@ -47,9 +47,16 @@ internals.response = {
     query: {
         name: 'adam'
     },
+    headers: {
+        'Content-Type': 'application/json'
+    },
     responsePayload: {
         foo: 'bar',
         value: 1
+    },
+    requestPayload: {
+        baz: 'qux',
+        number: 1
     }
 };
 internals.request = {
@@ -196,7 +203,7 @@ describe('GoodConsole', function () {
 
                     if (string.indexOf(timeString) === 0) {
                         stand.restore();
-                        expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms) \n');
+                        expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms)\n');
                     }
                     else {
                         stand.original(string, enc, callback);
@@ -212,6 +219,253 @@ describe('GoodConsole', function () {
                     expect(err).to.not.exist();
                     s.push(event);
                     s.push(null);
+                });
+            });
+
+            describe('logHeaders, logRequestPayload, logResponsePayload', function (){
+
+                it('logs to the console for "response" events with responsePayload if logResponsePayload is true', function (done) {
+
+                    var reporter = new GoodConsole({ response: '*' }, { logResponsePayload: true });
+                    var now = Date.now();
+                    var timeString = Moment.utc(now).format(internals.defaults.format);
+                    var event = Hoek.clone(internals.response);
+
+                    StandIn.replace(process.stdout, 'write', function (stand, string, enc, callback) {
+
+                        if (string.indexOf(timeString) === 0) {
+                            stand.restore();
+                            expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms) response payload: {\"foo\":\"bar\",\"value\":1}\n');
+                        }
+                        else {
+                            stand.original(string, enc, callback);
+                        }
+                    });
+
+                    event.timestamp = now;
+
+                    var s = internals.readStream(done);
+
+                    reporter.init(s, null, function (err) {
+
+                        expect(err).to.not.exist();
+                        s.push(event);
+                        s.push(null);
+                    });
+                });
+
+                it('logs to the console for "response" events with requestPayload if logRequestPayload is true', function (done) {
+
+                    var reporter = new GoodConsole({ response: '*' }, { logRequestPayload: true });
+                    var now = Date.now();
+                    var timeString = Moment.utc(now).format(internals.defaults.format);
+                    var event = Hoek.clone(internals.response);
+
+                    StandIn.replace(process.stdout, 'write', function (stand, string, enc, callback) {
+
+                        if (string.indexOf(timeString) === 0) {
+                            stand.restore();
+                            expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms) request payload: {\"baz\":\"qux\",\"number\":1} response payload: {\"foo\":\"bar\",\"value\":1}\n');
+                        }
+                        else {
+                            stand.original(string, enc, callback);
+                        }
+                    });
+
+                    event.timestamp = now;
+
+                    var s = internals.readStream(done);
+
+                    reporter.init(s, null, function (err) {
+
+                        expect(err).to.not.exist();
+                        s.push(event);
+                        s.push(null);
+                    });
+                });
+
+                it('logs to the console for "response" events with headers if logHeaders is true', function (done) {
+
+                    var reporter = new GoodConsole({ response: '*' }, { logHeaders: true });
+                    var now = Date.now();
+                    var timeString = Moment.utc(now).format(internals.defaults.format);
+                    var event = Hoek.clone(internals.response);
+
+                    StandIn.replace(process.stdout, 'write', function (stand, string, enc, callback) {
+
+                        if (string.indexOf(timeString) === 0) {
+                            stand.restore();
+                            expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms) headers: {\"Content-Type\":\"application/json\"} response payload: {\"foo\":\"bar\",\"value\":1}\n');
+                        }
+                        else {
+                            stand.original(string, enc, callback);
+                        }
+                    });
+
+                    event.timestamp = now;
+
+                    var s = internals.readStream(done);
+
+                    reporter.init(s, null, function (err) {
+
+                        expect(err).to.not.exist();
+                        s.push(event);
+                        s.push(null);
+                    });
+                });
+
+                it('logs to the console for "response" events without responsePayload if logResponePayload is false', function (done) {
+
+                    var reporter = new GoodConsole({ response: '*' }, { logResponsePayload: false });
+                    var now = Date.now();
+                    var timeString = Moment.utc(now).format(internals.defaults.format);
+                    var event = Hoek.clone(internals.response);
+
+                    StandIn.replace(process.stdout, 'write', function (stand, string, enc, callback) {
+
+                        if (string.indexOf(timeString) === 0) {
+                            stand.restore();
+                            expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms)\n');
+                        }
+                        else {
+                            stand.original(string, enc, callback);
+                        }
+                    });
+
+                    event.timestamp = now;
+
+                    var s = internals.readStream(done);
+
+                    reporter.init(s, null, function (err) {
+
+                        expect(err).to.not.exist();
+                        s.push(event);
+                        s.push(null);
+                    });
+                });
+
+                it('logs to the console for "response" events without requestPayload if logRequestPayload is false', function (done) {
+
+                    var reporter = new GoodConsole({ response: '*' }, { logRequestPayload: false });
+                    var now = Date.now();
+                    var timeString = Moment.utc(now).format(internals.defaults.format);
+                    var event = Hoek.clone(internals.response);
+
+                    StandIn.replace(process.stdout, 'write', function (stand, string, enc, callback) {
+
+                        if (string.indexOf(timeString) === 0) {
+                            stand.restore();
+                            expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms) response payload: {\"foo\":\"bar\",\"value\":1}\n');
+                        }
+                        else {
+                            stand.original(string, enc, callback);
+                        }
+                    });
+
+                    event.timestamp = now;
+
+                    var s = internals.readStream(done);
+
+                    reporter.init(s, null, function (err) {
+
+                        expect(err).to.not.exist();
+                        s.push(event);
+                        s.push(null);
+                    });
+                });
+
+                it('logs to the console for "response" events without headers if logHeaders is false', function (done) {
+
+                    var reporter = new GoodConsole({ response: '*' }, { logHeaders: false });
+                    var now = Date.now();
+                    var timeString = Moment.utc(now).format(internals.defaults.format);
+                    var event = Hoek.clone(internals.response);
+
+                    StandIn.replace(process.stdout, 'write', function (stand, string, enc, callback) {
+
+                        if (string.indexOf(timeString) === 0) {
+                            stand.restore();
+                            expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms) response payload: {\"foo\":\"bar\",\"value\":1}\n');
+                        }
+                        else {
+                            stand.original(string, enc, callback);
+                        }
+                    });
+
+                    event.timestamp = now;
+
+                    var s = internals.readStream(done);
+
+                    reporter.init(s, null, function (err) {
+
+                        expect(err).to.not.exist();
+                        s.push(event);
+                        s.push(null);
+                    });
+                });
+
+                it('logs to the console for "response" events without headers if logHeaders is true but headers is not present', function (done) {
+
+                    var reporter = new GoodConsole({ response: '*' }, { logHeaders: true });
+                    var now = Date.now();
+                    var timeString = Moment.utc(now).format(internals.defaults.format);
+                    var event = Hoek.clone(internals.response);
+
+                    delete event.headers;
+
+                    StandIn.replace(process.stdout, 'write', function (stand, string, enc, callback) {
+
+                        if (string.indexOf(timeString) === 0) {
+                            stand.restore();
+                            expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms) response payload: {\"foo\":\"bar\",\"value\":1}\n');
+                        }
+                        else {
+                            stand.original(string, enc, callback);
+                        }
+                    });
+
+                    event.timestamp = now;
+
+                    var s = internals.readStream(done);
+
+                    reporter.init(s, null, function (err) {
+
+                        expect(err).to.not.exist();
+                        s.push(event);
+                        s.push(null);
+                    });
+                });
+
+                it('logs to the console for "response" events without requestPayload if logRequestPayload is true but requestPAyload is not present', function (done) {
+
+                    var reporter = new GoodConsole({ response: '*' }, { logRequestPayload: true });
+                    var now = Date.now();
+                    var timeString = Moment.utc(now).format(internals.defaults.format);
+                    var event = Hoek.clone(internals.response);
+
+                    delete event.requestPayload;
+
+                    StandIn.replace(process.stdout, 'write', function (stand, string, enc, callback) {
+
+                        if (string.indexOf(timeString) === 0) {
+                            stand.restore();
+                            expect(string).to.equal(timeString + ', [response], localhost: [1;33mpost[0m /data {"name":"adam"} [32m200[0m (150ms) response payload: {\"foo\":\"bar\",\"value\":1}\n');
+                        }
+                        else {
+                            stand.original(string, enc, callback);
+                        }
+                    });
+
+                    event.timestamp = now;
+
+                    var s = internals.readStream(done);
+
+                    reporter.init(s, null, function (err) {
+
+                        expect(err).to.not.exist();
+                        s.push(event);
+                        s.push(null);
+                    });
                 });
             });
 
@@ -296,7 +550,7 @@ describe('GoodConsole', function () {
 
                     if (string.indexOf(timeString) === 0) {
 
-                        var expected = Hoek.format('%s, [response], localhost: [1;33mpost[0m /data  [%sm%s[0m (150ms) \n', timeString, colors[counter], counter * 100);
+                        var expected = Hoek.format('%s, [response], localhost: [1;33mpost[0m /data  [%sm%s[0m (150ms)\n', timeString, colors[counter], counter * 100);
                         expect(string).to.equal(expected);
 
                         counter++;


### PR DESCRIPTION
closes #36 

As you can see on line 199-206 I removed some trailing spaces. I consider this a bug in previous versions since they were there because of of Hoek.format leaving a space there when %s is not filled.