### PR TITLE
correct the key of the configuration object

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Lead Maintainer: [Adam Bretz](https://github.com/arb)
 
 `good-console` is a [good](https://github.com/hapijs/good) reporter implementation to write [hapi](http://hapijs.com/) server events to the console.
 
-## `GoodConsole(events, [options])`
+## `GoodConsole(events, [config])`
 Creates a new GoodConsole object with the following arguments:
 
 - `events` - an object of key value pairs.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Creates a new GoodConsole object with the following arguments:
 - `events` - an object of key value pairs.
 	- `key` - one of the supported [good events](https://github.com/hapijs/good) indicating the hapi event to subscribe to
 	- `value` - a single string or an array of strings to filter incoming events. "\*" indicates no filtering. `null` and `undefined` are assumed to be "\*"
-- `[options]` - optional object with the following available keys
+- `[config]` - optional configuration object with the following available keys
 	- `format` - [MomentJS](http://momentjs.com/docs/#/displaying/format/) format string. Defaults to 'YYMMDD/HHmmss.SSS'.
 	- `utc` - boolean controlling Moment using [utc mode](http://momentjs.com/docs/#/parsing/utc/) or not. Defaults to `true`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,13 +15,13 @@ var internals = {
     }
 };
 
-module.exports = internals.GoodConsole = function (events, options) {
+module.exports = internals.GoodConsole = function (events, config) {
 
     if (!(this instanceof internals.GoodConsole)) {
-        return new internals.GoodConsole(events, options);
+        return new internals.GoodConsole(events, config);
     }
-    options = options || {};
-    this._settings = Hoek.applyToDefaults(internals.defaults, options);
+    config = config || {};
+    this._settings = Hoek.applyToDefaults(internals.defaults, config);
     this._filter = new Squeeze(events);
 };
 


### PR DESCRIPTION
The documentation says the optional configuration should be given like this:
```js
options: { format: "YYYYMMDD" }
```
But should be "config", not "options":
```js
config: { format: "YYYYMMDD" }
```