### PR TITLE
event: Support for `wreck` event from `good`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Below are example outputs for the designated event type:
 - "request" - 141225/093015.900, [request, `event.tags`], data: {"message":"you made a request to a resource"}
 - "log" - 141225/093015.900, [log, `event.tags`], data: you logged a message
 - "response" - 141223/164207.694, [response], localhost: post /data {"name":"adam"} 200 (150ms) response payload: {"foo":"bar","value":1}
+- "wreck" - 141223/164207.694, [wreck], get: http://hapijs.com/test 200 OK (29ms)
+- "wreck" (with error) - 151105/084704.603, [wreck], get: http://hapijs.com/test (7ms) error: some error stack: some stack trace

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,6 @@ module.exports = internals.GoodConsole = function (events, config) {
     this._filter = new Squeeze(events);
 };
 
-
 internals.GoodConsole.prototype.init = function (stream, emitter, callback) {
 
     var self = this;
@@ -51,6 +50,11 @@ internals.GoodConsole.prototype.init = function (stream, emitter, callback) {
 
         if (eventName === 'response') {
             this.push(self._formatResponse(data, tags));
+            return next();
+        }
+
+        if (eventName ===  'wreck') {
+            this.push(self._formatWreck(data, tags));
             return next();
         }
 
@@ -99,7 +103,6 @@ internals.GoodConsole.prototype.init = function (stream, emitter, callback) {
     callback();
 };
 
-
 internals.GoodConsole.prototype._printEvent = function (event) {
 
     var m = Moment(parseInt(event.timestamp, 10));
@@ -112,37 +115,17 @@ internals.GoodConsole.prototype._printEvent = function (event) {
     return output + '\n';
 };
 
-
 internals.GoodConsole.prototype._formatResponse = function (event, tags) {
 
     var query = event.query ? JSON.stringify(event.query) : '';
     var responsePayload = '';
-    var statusCode = '';
 
     if (typeof event.responsePayload === 'object' && event.responsePayload) {
         responsePayload = 'response payload: ' + SafeStringify(event.responsePayload);
     }
 
-    var methodColors = {
-        get: 32,
-        delete: 31,
-        put: 36,
-        post: 33
-    };
-    var color = methodColors[event.method] || 34;
-    var method = '\x1b[1;' + color + 'm' + event.method + '\x1b[0m';
-
-    if (event.statusCode) {
-        color = 32;
-        if (event.statusCode >= 500) {
-            color = 31;
-        } else if (event.statusCode >= 400) {
-            color = 33;
-        } else if (event.statusCode >= 300) {
-            color = 36;
-        }
-        statusCode = '\x1b[' + color + 'm' + event.statusCode + '\x1b[0m';
-    }
+    var method = this._formatMethod(event.method);
+    var statusCode = this._formatStatusCode(event.statusCode) || '';
 
     return this._printEvent({
         timestamp: event.timestamp,
@@ -152,6 +135,54 @@ internals.GoodConsole.prototype._formatResponse = function (event, tags) {
     });
 };
 
+internals.GoodConsole.prototype._formatWreck = function (event, tags) {
+
+    var data, method, statusCode;
+    method = this._formatMethod(event.request.method);
+
+    if (event.error) {
+        data = Hoek.format('%s: %s (%sms) error: %s stack: %s', method, event.request.url, event.timeSpent, event.error.message, event.error.stack);
+    } else {
+        statusCode = this._formatStatusCode(event.response.statusCode);
+        data = Hoek.format('%s: %s %s %s (%sms)', method, event.request.url, statusCode, event.response.statusMessage, event.timeSpent);
+    }
+
+
+    return this._printEvent({
+        timestamp: event.timestamp,
+        tags: tags,
+        data: data
+    });
+};
+
+internals.GoodConsole.prototype._formatMethod = function (method) {
+
+    var methodColors = {
+        get: 32,
+        delete: 31,
+        put: 36,
+        post: 33
+    };
+    var color = methodColors[method.toLowerCase()] || 34;
+    return '\x1b[1;' + color + 'm' + method.toLowerCase() + '\x1b[0m';
+};
+
+internals.GoodConsole.prototype._formatStatusCode = function (statusCode) {
+
+    var color;
+    if (statusCode) {
+        color = 32;
+        if (statusCode >= 500) {
+            color = 31;
+        } else if (statusCode >= 400) {
+            color = 33;
+        } else if (statusCode >= 300) {
+            color = 36;
+        }
+        return '\x1b[' + color + 'm' + statusCode + '\x1b[0m';
+    }
+    return statusCode;
+};
 
 internals.GoodConsole.attributes = {
     pkg: require('../package.json')


### PR DESCRIPTION
Add support for `wreck` event from `good`.
Will output method, url, status and time.
Also supports wreck errors.
Added tests as well keeping 100% coverage.

I did rearrange some (factored out status code and method colorizing) and added some jsdoc comments.

Thanks!