### PR TITLE
force newline after output to console

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ internals.utility = {
         event.tags = event.tags.toString();
         const tags = ` [${event.tags}] `;
 
-        const output = `${timestamp},${tags}${event.data}`;
+        const output = `${timestamp},${tags}${event.data}\n`;
 
         return output;
     },


### PR DESCRIPTION
Are there any reason it is not the default behaviour? I really needed it for the readability in the console.