### PR TITLE
Output payloads to console.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Creates a new GoodConsole object with the following arguments:
 	- `format` - [MomentJS](http://momentjs.com/docs/#/displaying/format/) format string. Defaults to 'YYMMDD/HHmmss.SSS'.
 	- `utc` - boolean controlling Moment using [utc mode](http://momentjs.com/docs/#/parsing/utc/) or not. Defaults to `true`.
 	- `color` - a boolean specifying whether to output in color. Defaults to `true`.
+	- `requestPayload` a boolean specifying if passed request payload will be output to console. Defaults to `false`.
+	- `responsePayload` a boolean specifying if passed response payload will be output to console. Defaults to `false`.
 
 ## Output Formats
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,9 @@ const internals = {
     defaults: {
         format: 'YYMMDD/HHmmss.SSS',
         utc: true,
-        color: true
+        color: true,
+        requestPayload: false,
+        responsePayload: false
     }
 };
 
@@ -79,10 +81,23 @@ internals.utility = {
         const method = internals.utility.formatMethod(event.method, settings);
         const statusCode = internals.utility.formatStatusCode(event.statusCode, settings) || '';
 
+        let requestPayload = '';
+        let responsePayload = '';
+
+        if (settings.requestPayload && typeof event.requestPayload === 'object') {
+            const request = SafeStringify(event.requestPayload);
+            requestPayload = ` \n Request: ${request}`;
+        }
+
+        if (settings.responsePayload && typeof event.responsePayload === 'object') {
+            const response = SafeStringify(event.responsePayload);
+            responsePayload = ` \n Response: ${response}`;
+        }
+
         // event, timestamp, id, instance, labels, method, path, query, responseTime,
         // statusCode, pid, httpVersion, source, remoteAddress, userAgent, referer, log
         // method, pid, error
-        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseTime}ms)`;
+        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseTime}ms) ${requestPayload} ${responsePayload}`;
 
         const response = {
             timestamp: event.timestamp,

--- a/test/index.js
+++ b/test/index.js
@@ -68,6 +68,34 @@ internals.response = {
     }
 };
 
+internals.responseWithPayload = {
+    event: 'response',
+    timestamp: 1458264810957,
+    id: '1458264811279:localhost:16014:ilx17kv4:10001',
+    instance: 'http://localhost:61253',
+    labels: [],
+    method: 'post',
+    path: '/data',
+    query: {
+        name: 'adam'
+    },
+    responseTime: 150,
+    statusCode: 200,
+    pid: 16014,
+    httpVersion: '1.1',
+    source: {
+        remoteAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36',
+        referer: 'http://localhost:61253/'
+    },
+    requestPayload: {
+        foo: 'bar'
+    },
+    responsePayload: {
+        bar: 'foo'
+    }
+};
+
 internals.request = {
     event: 'request',
     timestamp: 1458264810957,
@@ -126,7 +154,58 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)  \n');
+                    done();
+                });
+            });
+
+            it('returns a formatted string for "response" events with a requestPayload', { plan: 2 }, (done) => {
+
+                const reporter = new GoodConsole({ requestPayload: true });
+                const out = new Streams.Writer();
+                const reader = new Streams.Reader();
+
+                reader.pipe(reporter).pipe(out);
+                reader.push(internals.responseWithPayload);
+                reader.push(null);
+                reader.once('end', () => {
+
+                    expect(out.data).to.have.length(1);
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {\"name\":\"adam\"} \u001b[32m200\u001b[0m (150ms)  \n Request: {\"foo\":\"bar\"} \n');
+                    done();
+                });
+            });
+
+            it('returns a formatted string for "response" events with a responsePayload', { plan: 2 }, (done) => {
+
+                const reporter = new GoodConsole({ responsePayload: true });
+                const out = new Streams.Writer();
+                const reader = new Streams.Reader();
+
+                reader.pipe(reporter).pipe(out);
+                reader.push(internals.responseWithPayload);
+                reader.push(null);
+                reader.once('end', () => {
+
+                    expect(out.data).to.have.length(1);
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {\"name\":\"adam\"} \u001b[32m200\u001b[0m (150ms)   \n Response: {\"bar\":\"foo\"}\n');
+                    done();
+                });
+            });
+
+            it('returns a formatted string for "response" events with a requestPayload and responsePayload', { plan: 2 }, (done) => {
+
+                const reporter = new GoodConsole({ requestPayload: true, responsePayload: true });
+                const out = new Streams.Writer();
+                const reader = new Streams.Reader();
+
+                reader.pipe(reporter).pipe(out);
+                reader.push(internals.responseWithPayload);
+                reader.push(null);
+                reader.once('end', () => {
+
+                    expect(out.data).to.have.length(1);
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {\"name\":\"adam\"} \u001b[32m200\u001b[0m (150ms)  \n Request: {\"foo\":\"bar\"}  \n Response: {\"bar\":\"foo\"}\n');
                     done();
                 });
             });
@@ -147,7 +226,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data  \u001b[32m200\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data  \u001b[32m200\u001b[0m (150ms)  \n');
                     done();
                 });
             });
@@ -169,7 +248,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"}  (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"}  (150ms)  \n');
                     done();
                 });
             });
@@ -188,7 +267,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: post /data {"name":"adam"} 200 (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: post /data {"name":"adam"} 200 (150ms)  \n');
                     done();
                 });
             });
@@ -212,7 +291,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal(`${date}, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)\n`);
+                    expect(out.data[0]).to.be.equal(`${date}, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)  \n`);
                     done();
                 });
             });
@@ -234,7 +313,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;34mhead\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;34mhead\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)  \n');
                     done();
                 });
             });
@@ -256,7 +335,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[31m599\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[31m599\u001b[0m (150ms)  \n');
                     done();
                 });
             });
@@ -278,7 +357,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[33m418\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[33m418\u001b[0m (150ms)  \n');
                     done();
                 });
             });
@@ -300,7 +379,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[36m304\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[36m304\u001b[0m (150ms)  \n');
                     done();
                 });
             });


### PR DESCRIPTION
I added the ability to pass the request and response payload to the console. 

A couple of notes: 
- I made it optional with a default to false
- The good package options has to be set to include the requested payloads. 

ie: 
```
const Logging = {
	register: require('good'),
	options: {
		reporters: {
			console: [{
				module: 'good-squeeze',
				name: 'Squeeze',
				args: [{
					log: '*',
					request: '*',
					error: '*',
				}],
			}, {
				module: 'good-console',
				args: [{
					responsePayload: true,
				}],
			}, 'stdout'],
		},
		includes: {
			request: ['payload'],
			response: ['payload'],
		},
	},
};
```
