### PR TITLE
add hapi as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "code": "3.x.x",
     "lab": "10.x.x"
   },
+  "peerDependencies": {
+    "hapi": ">=10.x.x"
+  },
   "engines": {
     "node": ">=4.x.x"
   },


### PR DESCRIPTION
in another project that makes extensive use of the hapi suite, I was receiving the message: 

UNMET PEER DEPENDENCY hapi@15.1.1 while installing good-console

I don't know if this will resolve it, but wanted to at least raise the issue.