### PR TITLE
Bump moment to 2.15.x branch to resolve Regex DOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hoek": "4.x.x",
     "joi": "8.1.x",
     "json-stringify-safe": "5.0.x",
-    "moment": "2.13.x"
+    "moment": "2.15.x"
   },
   "devDependencies": {
     "code": "3.x.x",


### PR DESCRIPTION
Howdy, `good-console` maintainers.  I just got an alert about a Regex DOS from snyk.io.  Figured I could help by updating your dependency here.  I can't see any reason why you're pinned to the minor version of `moment`, so I just bumped to the 2.15 branch.  

[Moment's changelog](https://github.com/moment/moment/blob/dc1e659b34365c98896e73e2e858f9efa4b3d5dc/CHANGELOG.md)

See more information here: 
 - https://snyk.io/test/npm/good-console/6.1.2
 - https://snyk.io/vuln/npm:moment:20161019