### PR TITLE
log event.id when available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,10 @@ internals.utility = {
         event.tags = event.tags.toString();
         const tags = ` [${event.tags}] `;
 
-        const output = `${timestamp},${tags}${event.data}`;
+        // add event id information if available, typically for 'request' events
+        const id = event.id && ` (${event.id}) ` || '';
+
+        const output = `${timestamp},${id}${tags}${event.data}`;
 
         return output + `\n`;
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ internals.utility = {
         const tags = ` [${event.tags}] `;
 
         // add event id information if available, typically for 'request' events
-        const id = event.id && ` (${event.id}) ` || '';
+        const id = event.id ? ` (${event.id})` : '';
 
         const output = `${timestamp},${id}${tags}${event.data}`;
 
@@ -130,6 +130,7 @@ internals.utility = {
 
         const defaults = {
             timestamp: event.timestamp,
+            id: event.id,
             tags,
             data: output
         };

--- a/test/index.js
+++ b/test/index.js
@@ -368,7 +368,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [request,user,info] data: you made a request\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1419005623332:new-host.local:48767:i3vrb3z7:10000) [request,user,info] data: you made a request\n');
                     done();
                 });
             });


### PR DESCRIPTION
This PR is partly for discussion, but it's a feature that we would like to use - adding the `request.id` in the `request` event log from good-console. This makes it much easier to connect the `request.log` calls that correspond to a particular request rather than the 'anonymous' logs that would otherwise be printed.

Let me know what you think - we can definitely write our own Good stream/reporter, but I figure this might be generally useful.

Downsides

1. more verbose logging (but not much more verbose)
2. changing the logging output might break custom log parsers that are tuned to the existing good-console output
3. the current formatting in this PR doesn't 'tag' the `event.id` with anything other than parens, which might make it less `grep`able

Thoughts?

