### PR TITLE
separated message and stack with a comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Creates a new GoodConsole object with the following arguments:
 Below are example outputs for the designated event type:
 
 - "ops" - 160318/013330.957, [ops] memory: 29Mb, uptime (seconds): 6, load: [1.650390625,1.6162109375,1.65234375]
-- "error" - 160318/013330.957, [error,`event.tags`] message: Just a simple error stack: `event.error.stack`
+- "error" - 160318/013330.957, [error,`event.tags`] message: Just a simple error, stack: `event.error.stack`
 - "request" - 160318/013330.957, [request,`event.tags`] data: you made a request
 - "log" - 160318/013330.957, [log,`event.tags`] data: you made a default
 - "response" - 160318/013330.957, [response, `event.tags`] http://localhost:61253: post /data {"name":"adam"} 200 (150ms)

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,7 @@ internals.utility = {
 
     formatError(event, tags, settings) {
 
-        const output = `message: ${event.error.message} stack: ${event.error.stack}`;
+        const output = `message: ${event.error.message}, stack: ${event.error.stack}`;
 
         const error = {
             timestamp: event.timestamp,

--- a/test/index.js
+++ b/test/index.js
@@ -346,7 +346,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [error,user,info] message: Just a simple error stack: Error: Just a simple Error\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [error,user,info] message: Just a simple error, stack: Error: Just a simple Error\n');
                     done();
                 });
             });


### PR DESCRIPTION
this matches the separation in the other formatters and makes it more clear that "stack" is not part of the error message