### PR TITLE
leveraged the error formatter when data is an Error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -174,6 +174,12 @@ class GoodConsole extends Stream.Transform {
             return next(null, internals.utility.formatResponse(data, tags, this._settings));
         }
 
+        if (data.data instanceof Error) {
+            const error = data.data;
+
+            return next(null, internals.utility.formatError(Object.assign(data, { error }), tags, this._settings));
+        }
+
         if (!data.data) {
             data.data = '(none)';
         }

--- a/test/index.js
+++ b/test/index.js
@@ -460,6 +460,28 @@ describe('GoodConsole', () => {
                     done();
                 });
             });
+
+            it('returns a formatted string for "default" events with data as Error', { plan: 2 }, (done) => {
+
+                const reporter = new GoodConsole();
+                const out = new Streams.Writer();
+                const reader = new Streams.Reader();
+
+                reader.pipe(reporter).pipe(out);
+
+                const defaultEvent = Object.assign({}, internals.default);
+                defaultEvent.data = new Error('you logged an error');
+
+                reader.push(defaultEvent);
+                reader.push(null);
+
+                reader.once('end', () => {
+
+                    expect(out.data).to.have.length(1);
+                    expect(out.data[0].split('\n')[0]).to.be.equal('160318/013330.957, [request,user,info] message: you logged an error stack: Error: you logged an error');
+                    done();
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
for events that are not handled specifically by eventName, the error formatter is used to provide more useful information when the event data is an Error

this is my solution to #84 for local logging. while you suggested my own transform, this seemed like a simple enough change that it might make sense to include. if i could convince you that it aligns with the goals of the project, i would love to not have the need to maintain my own fork in order to have this visibility into errors.

i'm happy to make adjustments if there are things that would make it better align with the project