### PR TITLE
add handling for tail logs, toggled in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Creates a new GoodConsole object with the following arguments:
 	- `format` - [MomentJS](http://momentjs.com/docs/#/displaying/format/) format string. Defaults to 'YYMMDD/HHmmss.SSS'.
 	- `utc` - boolean controlling Moment using [utc mode](http://momentjs.com/docs/#/parsing/utc/) or not. Defaults to `true`.
 	- `color` - a boolean specifying whether to output in color. Defaults to `true`.
+	- `requestTails` - log request tail activities like response validation. Accepts `'*'` or an array of tags. Defaults to disabled.
 
 ## Output Formats
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,11 +11,29 @@ const internals = {
     defaults: {
         format: 'YYMMDD/HHmmss.SSS',
         utc: true,
-        color: true
+        color: true,
+        requestTails: []
     }
 };
 
 internals.utility = {
+
+    setupTags(eventName, eventTags) {
+
+        let tags = [];
+
+        if (Array.isArray(eventTags)) {
+            tags = eventTags.concat([]);
+        }
+        else if (eventTags) {
+            tags = [eventTags];
+        }
+
+        tags.unshift(eventName);
+
+        return tags;
+    },
+
     formatOutput(event, settings) {
 
         let timestamp = Moment(parseInt(event.timestamp, 10));
@@ -76,6 +94,43 @@ internals.utility = {
         return statusCode;
     },
 
+    formatRequest(event, tags, settings) {
+
+        const dataObject = typeof event.data === 'object' ? event.data : { message: event.data };
+        const data = SafeStringify(Object.assign({ request: event.request }, dataObject));
+
+        const request = {
+            timestamp: event.timestamp,
+            tags,
+            data
+        };
+
+        return internals.utility.formatOutput(request, settings);
+    },
+
+    formatTailEvents(tailLog, settings) {
+
+        const formatTailEntry = (entry) => internals.utility.formatRequest(entry, internals.utility.setupTags('request', entry.tags), settings);
+
+        const allowAny = settings.requestTails === '*';
+
+        const hasRequestedTag = (entry) => {
+
+            const requestedTagsSet = new Set(settings.requestTails);
+            for (const elem of entry.tags) {
+                if (requestedTagsSet.has(elem)) {
+                    return true;
+                };
+            }
+            return false;
+        };
+
+        const onlyRequestedTags = (entry) => allowAny || hasRequestedTag(entry);
+
+        return tailLog.filter(onlyRequestedTags).map(formatTailEntry);
+    },
+
+
     formatResponse(event, tags, settings) {
 
         const query = event.query ? JSON.stringify(event.query) : '';
@@ -85,15 +140,24 @@ internals.utility = {
         // event, timestamp, id, instance, labels, method, path, query, responseTime,
         // statusCode, pid, httpVersion, source, remoteAddress, userAgent, referer, log
         // method, pid, error
-        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseTime}ms)`;
+        const responseOutput = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseTime}ms)`;
 
         const response = {
             timestamp: event.timestamp,
             tags,
-            data: output
+            data: responseOutput
         };
 
-        return internals.utility.formatOutput(response, settings);
+        const formattedResponse = internals.utility.formatOutput(response, settings);
+
+        if (Array.isArray(settings.requestTails) && settings.requestTails.length === 0) {
+            return formattedResponse;
+        };
+
+        const tails = internals.utility.formatTailEvents(event.log, settings);
+        const output = [...tails, formattedResponse];
+
+        return output.join('');
     },
 
     formatOps(event, tags, settings) {
@@ -151,16 +215,7 @@ class GoodConsole extends Stream.Transform {
     _transform(data, enc, next) {
 
         const eventName = data.event;
-        let tags = [];
-
-        if (Array.isArray(data.tags)) {
-            tags = data.tags.concat([]);
-        }
-        else if (data.tags) {
-            tags = [data.tags];
-        }
-
-        tags.unshift(eventName);
+        const tags = internals.utility.setupTags(eventName, data.tags);
 
         if (eventName === 'error') {
             return next(null, internals.utility.formatError(data, tags, this._settings));

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,7 +155,7 @@ internals.utility = {
         };
 
         const tails = internals.utility.formatTailEvents(event.log, settings);
-        const output = [...tails, formattedResponse];
+        const output = [].concat(tails).concat([formattedResponse]);
 
         return output.join('');
     },


### PR DESCRIPTION
Fixes #92 

Adds a `requestTails` property to the config - if this is not set, or set to an empty array, it short-circuits everything.

Not sure if this is the best way to go about it, but I thought I'd have a go.

Also not sure if it's appropriate to use `=>` and `Set`, did that based on existing use of const but I can refactor if needed.

First Node PR in a couple of years, any feedback gratefully received!