### PR TITLE
Add responseSentTime to response format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ internals.utility = {
 
         const output = `${timestamp},${id}${tags}${event.data}`;
 
-        return output + `\n`;
+        return output + '\n';
     },
 
     formatMethod(method, settings) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,10 +82,10 @@ internals.utility = {
         const method = internals.utility.formatMethod(event.method, settings);
         const statusCode = internals.utility.formatStatusCode(event.statusCode, settings) || '';
 
-        // event, timestamp, id, instance, labels, method, path, query, responseTime,
+        // event, timestamp, id, instance, labels, method, path, query, responseTime, responseSentTime,
         // statusCode, pid, httpVersion, source, remoteAddress, userAgent, referer, log
         // method, pid, error
-        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseTime}ms)`;
+        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseSentTime}ms) (${event.responseTime}ms)`;
 
         const response = {
             timestamp: event.timestamp,

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ internals.utility = {
         // event, timestamp, id, instance, labels, method, path, query, responseTime, responseSentTime,
         // statusCode, pid, httpVersion, source, remoteAddress, userAgent, referer, log
         // method, pid, error
-        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseSentTime}ms) (${event.responseTime}ms)`;
+        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (responseSentTime: ${event.responseSentTime}ms) (responseTime: ${event.responseTime}ms)`;
 
         const response = {
             timestamp: event.timestamp,

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "moment": "2.15.x"
   },
   "devDependencies": {
-    "code": "3.x.x",
-    "lab": "10.x.x"
+    "lab": "^14.x.x"
   },
   "engines": {
     "node": ">=4.x.x"

--- a/test/index.js
+++ b/test/index.js
@@ -128,7 +128,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (100ms) (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -149,7 +149,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data  \u001b[32m200\u001b[0m (100ms) (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data  \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -171,7 +171,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"}  (100ms) (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"}  (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -190,7 +190,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: post /data {"name":"adam"} 200 (100ms) (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: post /data {"name":"adam"} 200 (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -214,7 +214,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal(`${date}, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (100ms) (150ms)\n`);
+                    expect(out.data[0]).to.be.equal(`${date}, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n`);
                     done();
                 });
             });
@@ -236,7 +236,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;34mhead\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (100ms) (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;34mhead\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -258,7 +258,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[31m599\u001b[0m (100ms) (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[31m599\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -280,7 +280,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[33m418\u001b[0m (100ms) (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[33m418\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -302,7 +302,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[36m304\u001b[0m (100ms) (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[36m304\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,7 @@ internals.ops = {
         requests: {},
         concurrents: {},
         responseTimes: {},
+        responseSentTimes: {},
         listener: {},
         sockets: { http: {}, https: {} }
     }
@@ -58,6 +59,7 @@ internals.response = {
         name: 'adam'
     },
     responseTime: 150,
+    responseSentTime: 100,
     statusCode: 200,
     pid: 16014,
     httpVersion: '1.1',
@@ -126,7 +128,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (100ms) (150ms)\n');
                     done();
                 });
             });
@@ -147,7 +149,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data  \u001b[32m200\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data  \u001b[32m200\u001b[0m (100ms) (150ms)\n');
                     done();
                 });
             });
@@ -169,7 +171,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"}  (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"}  (100ms) (150ms)\n');
                     done();
                 });
             });
@@ -188,7 +190,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: post /data {"name":"adam"} 200 (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: post /data {"name":"adam"} 200 (100ms) (150ms)\n');
                     done();
                 });
             });
@@ -212,7 +214,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal(`${date}, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)\n`);
+                    expect(out.data[0]).to.be.equal(`${date}, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (100ms) (150ms)\n`);
                     done();
                 });
             });
@@ -234,7 +236,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;34mhead\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;34mhead\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (100ms) (150ms)\n');
                     done();
                 });
             });
@@ -256,7 +258,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[31m599\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[31m599\u001b[0m (100ms) (150ms)\n');
                     done();
                 });
             });
@@ -278,7 +280,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[33m418\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[33m418\u001b[0m (100ms) (150ms)\n');
                     done();
                 });
             });
@@ -300,7 +302,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[36m304\u001b[0m (150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[36m304\u001b[0m (100ms) (150ms)\n');
                     done();
                 });
             });


### PR DESCRIPTION
Added `responseSentTime` to the response format and updated the unit tests. Questions left open:

1. This could be a breaking change for people who parse the logs. Should this be opt-in?
2. Should we tell which time is which in the log format?

Ideally, it should not be a breaking change and we will be able to pass in a format string for responses. Is this commit a good start?

Addresses https://github.com/hapijs/good-console/issues/94