### PR TITLE
Add responseExtension option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Creates a new GoodConsole object with the following arguments:
 	- `format` - [MomentJS](http://momentjs.com/docs/#/displaying/format/) format string. Defaults to 'YYMMDD/HHmmss.SSS'.
 	- `utc` - boolean controlling Moment using [utc mode](http://momentjs.com/docs/#/parsing/utc/) or not. Defaults to `true`.
 	- `color` - a boolean specifying whether to output in color. Defaults to `true`.
+	- `responseExtension` - optional function to append custom output to response log lines. The function takes a Good reponse log event as the argument and returns a string. E.g.:
+		
+			new GoodConsole({
+				responseExtension => `User agent: ${event.source.userAgent}`
+			});
 
 ## Output Formats
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ internals.utility = {
 
         const output = `${timestamp},${id}${tags}${event.data}`;
 
-        return output + `\n`;
+        return output + '\n';
     },
 
     formatMethod(method, settings) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,10 +82,12 @@ internals.utility = {
         const method = internals.utility.formatMethod(event.method, settings);
         const statusCode = internals.utility.formatStatusCode(event.statusCode, settings) || '';
 
+        const responseExtension = settings.responseExtension ? ` ${settings.responseExtension(event)}` : '';
+
         // event, timestamp, id, instance, labels, method, path, query, responseTime,
         // statusCode, pid, httpVersion, source, remoteAddress, userAgent, referer, log
         // method, pid, error
-        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseTime}ms)`;
+        const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (${event.responseTime}ms)${responseExtension}`;
 
         const response = {
             timestamp: event.timestamp,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "code": "3.x.x",
-    "lab": "10.x.x"
+    "lab": "13.1.x"
   },
   "engines": {
     "node": ">=4.x.x"

--- a/test/index.js
+++ b/test/index.js
@@ -304,6 +304,30 @@ describe('GoodConsole', () => {
                     done();
                 });
             });
+
+            it('appends the result of the responseExtension function', { plan: 3 }, (done) => {
+
+                const reporter = new GoodConsole({
+
+                    responseExtension: (event) => {
+
+                        expect(event.event).to.be.equal('response');
+                        return event.source.remoteAddress;
+                    }
+                });
+                const out = new Streams.Writer();
+                const reader = new Streams.Reader();
+
+                reader.pipe(reporter).pipe(out);
+                reader.push(internals.response);
+                reader.push(null);
+                reader.once('end', () => {
+
+                    expect(out.data).to.have.length(1);
+                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (150ms) 127.0.0.1\n');
+                    done();
+                });
+            });
         });
 
         describe('ops events', () => {


### PR DESCRIPTION
I have some extra fields I need to get into the logs for response events.  The idea of this change is to allow users to supply a function which will be evaluated with the response event and the result appended to the log line.   Users can then append user agent, route, source IP etc. as desired.

This should be backwards compatible.

Also bumped Lab version to include a fix so tests pass on Node v8 (https://github.com/hapijs/lab/pull/704).  Latest versions of Lab seem to be incompatible with current tests.