### PR TITLE
Pass event.id for Error and Response format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ internals.utility = {
         const output = `${event.instance}: ${method} ${event.path} ${query} ${statusCode} (responseSentTime: ${event.responseSentTime}ms) (responseTime: ${event.responseTime}ms)`;
 
         const response = {
+            id: event.id,
             timestamp: event.timestamp,
             tags,
             data: output
@@ -115,6 +116,7 @@ internals.utility = {
         const output = `message: ${event.error.message}, stack: ${event.error.stack}`;
 
         const error = {
+            id: event.id,
             timestamp: event.timestamp,
             tags,
             data: output

--- a/test/index.js
+++ b/test/index.js
@@ -127,7 +127,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -148,7 +148,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data  \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data  \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -170,7 +170,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"}  (responseSentTime: 100ms) (responseTime: 150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"}  (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -189,7 +189,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: post /data {"name":"adam"} 200 (responseSentTime: 100ms) (responseTime: 150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: post /data {"name":"adam"} 200 (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -213,7 +213,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal(`${date}, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n`);
+                    expect(out.data[0]).to.be.equal(`${date}, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n`);
                     done();
                 });
             });
@@ -235,7 +235,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;34mhead\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: \u001b[1;34mhead\u001b[0m /data {"name":"adam"} \u001b[32m200\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -257,7 +257,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[31m599\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[31m599\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -279,7 +279,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[33m418\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[33m418\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -301,7 +301,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[36m304\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1458264811279:localhost:16014:ilx17kv4:10001) [response] http://localhost:61253: \u001b[1;33mpost\u001b[0m /data {"name":"adam"} \u001b[36m304\u001b[0m (responseSentTime: 100ms) (responseTime: 150ms)\n');
                     done();
                 });
             });
@@ -347,7 +347,7 @@ describe('GoodConsole', () => {
                 reader.once('end', () => {
 
                     expect(out.data).to.have.length(1);
-                    expect(out.data[0]).to.be.equal('160318/013330.957, [error,user,info] message: Just a simple error, stack: Error: Just a simple Error\n');
+                    expect(out.data[0]).to.be.equal('160318/013330.957, (1419005623332:new-host.local:48767:i3vrb3z7:10000) [error,user,info] message: Just a simple error, stack: Error: Just a simple Error\n');
                     done();
                 });
             });


### PR DESCRIPTION
Hi,
The accepted PR #80 was very useful for my case but I don't understand why the id is only set into the `formatDefault` function. We could also take advantage of it for error and response.
Any thoughts ? 