### PR TITLE
Use SafeStringify when serializing the query

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ internals.utility = {
 
     formatResponse(event, tags, settings) {
 
-        const query = event.query ? JSON.stringify(event.query) : '';
+        const query = event.query ? SafeStringify(event.query) : '';
         const method = internals.utility.formatMethod(event.method, settings);
         const statusCode = internals.utility.formatStatusCode(event.statusCode, settings) || '';
 


### PR DESCRIPTION
On hapi services a query object can pass through multiple stages and plugins. Some of those plugins can inadvertently inject non-serializable data (like circular references). Since you already have `SafeStringify` available  i think it makes sense to use it for this serialization too.

@noeliacuesta