### PR TITLE
Format errors passed as data to request.log

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,7 @@ class GoodConsole extends Stream.Transform {
 
         tags.unshift(eventName);
 
-        if (eventName === 'error') {
+        if (eventName === 'error' || data.error instanceof Error) {
             return next(null, internals.utility.formatError(data, tags, this._settings));
         }
 
@@ -174,12 +174,6 @@ class GoodConsole extends Stream.Transform {
 
         if (eventName === 'response') {
             return next(null, internals.utility.formatResponse(data, tags, this._settings));
-        }
-
-        if (data.data instanceof Error) {
-            const error = data.data;
-
-            return next(null, internals.utility.formatError(Object.assign(data, { error }), tags, this._settings));
         }
 
         if (!data.data) {

--- a/test/index.js
+++ b/test/index.js
@@ -469,7 +469,7 @@ describe('GoodConsole', () => {
                 reader.pipe(reporter).pipe(out);
 
                 const defaultEvent = Object.assign({}, internals.default);
-                defaultEvent.data = new Error('you logged an error');
+                defaultEvent.error = new Error('you logged an error');
 
                 reader.push(defaultEvent);
                 reader.push(null);


### PR DESCRIPTION
This PR attempts to address #84 where `request.log(['error', 'database', 'read'], new Error('message'))` results in empty data being logged. It appears #86 no longer applies. When an error is passed as data to `request.log`, [it is assigned to an `error` field. ](https://github.com/hapijs/hapi/commit/e8ca1d92b11eef32c063c0a47110e30e0dfe2e33#diff-f265d6a6b6b64d4d096fddcf7d620a76R538)