### PR TITLE
Update lab

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "code": "4.x.x",
-    "lab": "14.x.x"
+    "lab": "18.x.x"
   },
   "engines": {
     "node": ">=4.x.x"


### PR DESCRIPTION
It displays leaks in Node v11 whereas they are well-known globals that lab is not aware of.